### PR TITLE
version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+Version 0.3.0
+
+* Breaking: fix a typo where the unknown token would be returned as `[UNK±`
+  instead of `[UNK]`
+* Breaking: fix offsets returned when used as `Model` which were previously
+  falsely given in bytes instead of characters
+* add fuzzing check against wordpiece
+* fix benchmark run without `huggingface` feature
+
+Version 0.2.0
+
+* Breaking: fix a bug where the tokenizer would select the wrong token ID if
+  one token was a prefix of another one which was off by the last character
+* Breaking: Introduce the `huggingface` feature so this crate no longer depends
+  on `tokenizers` by default
+
+Version 0.1.0
+
+* The initial public release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "aleph-alpha-tokenizer"
 readme = "README.md"
 repository = "https://github.com/Aleph-Alpha/aleph-alpha-tokenizer"
-version = "0.2.0"
+version = "0.3.0"
 
 [features]
 # Enable this to allow using the tokenizer as a `tokenizer::Model`
@@ -17,7 +17,7 @@ huggingface = ["tokenizers"]
 default = []
 
 [dependencies]
-tokenizers = { version = "0.9.0", optional = true }
+tokenizers = { version = "0.10.1", optional = true }
 fst = "0.4.3"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -19,28 +19,32 @@ avoiding needless allocation, re-using data, generics).
 We are very happy with the improved performance. In our tests, we found our
 tokenizer performed mostly linearly with whatever data was thrown at it, while
 the huggingface `wordpiece` tokenizer performs quadratically worse with longer
-words. The following single-core runtimes in µs were measured for a set of
-benchmarks:
+multi-token words. The following single-core runtimes in µs were measured for
+a set of benchmarks:
 
 | # |AlephAlphaTokenizer | ~ as Model | wordpiece |
 |---|--------------------|------------|-----------|
-| 0 |  780.927           | 1251.911   |  2134.343 |
-| 1 | 1000.583           | 1452.931   |  1870.142 |
-| 2 | 3240.754           | 4659.755   |  9540.037 |
-| 3 | 1772.298           | 2504.794   |  3001.438 |
-| 4 | 2376.060           | 3437.649   | 13287.062 |
-| 5 | 3270.748           | 4530.615   |  7985.852 |
-| 6 | 3813.023           | 5549.230   |  9130.947 |
-| 7 | 3173.984           | 4259.019   | 18975.838 |
-| 8 | 4811.540           | 6590.099   | 11097.789 |
-| 9 | 2896.895           | 3771.085   |  5378.582 |
+| 0 |            749.950 |   1274.923 |  2025.289 |
+| 1 |           1010.120 |   1511.214 |  1900.441 |
+| 2 |           1775.973 |   2648.909 |  2995.574 |
+| 3 |           2263.436 |   3598.771 | 12978.049 |
+| 4 |           2262.490 |   3403.918 |  4864.752 |
+| 5 |           2808.373 |   4456.960 | 18623.648 |
+| 6 |           2783.996 |   4015.472 |  5362.356 |
+| 7 |           3160.517 |   5048.136 |  9946.745 |
+| 8 |           3016.781 |   4742.037 |  8066.818 |
+| 9 |           3497.266 |   5626.896 |  8662.281 |
+|10 |           4446.626 |   6679.859 | 10584.524 |
 
 (This was measured on an Intel(R) Core(TM) i7-7600U CPU @ 2.80GHz running on
-a Fedora kernel 5.5.13-200.fc31.x86_64 with all mitigations enabled)
+a Fedora kernel 5.6.15-300.fc32.x86_64 with all mitigations enabled)
 
 As you can see, using our tokenizer as a model is faster than huggingface's 
-wordpiece tokenizer by at least 20%, often more. Using the rustic interface, we 
-can omit a lot of allocation and memory copying, so we are at least 45% faster.
+wordpiece tokenizer by at least 13%, often more. Using the rustic interface, we 
+can omit a lot of allocation and memory copying, so we are at least 60% faster.
+
+To re-run the benchmark, call `cargo bench --all-features`. Otherwise only the
+`AlephAlphaTokenizer` will be benchmarked.
 
 # License
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,24 +1,25 @@
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 
 use aleph_alpha_tokenizer::AlephAlphaTokenizer;
-use tokenizers::models::wordpiece::WordPiece;
-use tokenizers::tokenizer::Model;
+#[cfg(feature = "huggingface")]
+use tokenizers::{models::wordpiece::WordPiece, tokenizer::Model};
 
 static TEXT_LIST: &[&str] = &[
-	"Ich esse Steak.",
-	"Der Hund spielt im Garten.",
-	"Gibt es genügend Impfstoff gegen FSME angesichts der steigenden Infektionszahlen?",
-	"Ein Junge im Kindergarten spielt mit dem Ball.",
-	"Wie definiert die Bundesregierung Clans und Clankriminalität?",
-	"Gibt es genügend Impfstoff gegen Corona angesichts der steigenden Infektionszahlen?",
-	"Steht vor dem Hintergrund der gestiegenen Infektionen ausreichend Impfstoff gegen FSME zur Verfügung?",
-	"Wie viele Menschen starben durch die Folgen der Borreliose-Erkrankung?",
-	"Liegen der Bundesregierung statistische Daten zu Todesfällen in Folge von Borreliose vor und wenn ja, wie lauten diese?",
-	"Welche Abkommen mit auswärtigen Staaten bestehen seitens welcher Länder aktuell?",
-	"Welche Vereinbarungen auf Landesebene bestehen mit Drittstaaten?",
+    "Ich esse Steak.",
+    "Der Hund spielt im Garten.",
+    "Ein Junge im Kindergarten spielt mit dem Ball.",
+    "Wie definiert die Bundesregierung Clans und Clankriminalität?",
+    "Welche Vereinbarungen auf Landesebene bestehen mit Drittstaaten?",
+    "Wie viele Menschen starben durch die Folgen der Borreliose-Erkrankung?",
+    "Welche Abkommen mit auswärtigen Staaten bestehen seitens welcher Länder aktuell?",
+    "Gibt es genügend Impfstoff gegen FSME angesichts der steigenden Infektionszahlen?",
+    "Gibt es genügend Impfstoff gegen Corona angesichts der steigenden Infektionszahlen?",
+    "Steht vor dem Hintergrund der gestiegenen Infektionen ausreichend Impfstoff gegen FSME zur Verfügung?",
+    "Liegen der Bundesregierung statistische Daten zu Todesfällen in Folge von Borreliose vor und wenn ja, wie lauten diese?",
 ];
 
 fn compare_aleph_wordpiece(c: &mut Criterion) {
+    #[cfg(feature = "huggingface")]
     let wordpiece = WordPiece::from_files("vocab.txt")
         .unk_token("[UNK]".to_string())
         .build()
@@ -32,9 +33,11 @@ fn compare_aleph_wordpiece(c: &mut Criterion) {
             words.push((word.to_string(), (o, o + word.len())));
             o += word.len() + 1;
         }
+        #[cfg(feature = "huggingface")]
         group.bench_with_input(BenchmarkId::new("wordpiece", i), &i, |b, _| {
             b.iter(|| wordpiece.tokenize(black_box(words.clone())))
         });
+        #[cfg(feature = "huggingface")]
         group.bench_with_input(BenchmarkId::new("aleph_alpha_model", i), &i, |b, _| {
             b.iter(|| aleph_alpha.tokenize(black_box(words.clone())))
         });

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,27 @@
+
+[package]
+name = "aleph-alpha-tokenizer-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+once_cell = "1.4.0"
+tokenizers = "0.10.1"
+
+[dependencies.aleph-alpha-tokenizer]
+path = ".."
+features = ["huggingface"]
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "wordpiece"
+path = "fuzz_targets/wordpiece.rs"

--- a/fuzz/fuzz_targets/wordpiece.rs
+++ b/fuzz/fuzz_targets/wordpiece.rs
@@ -1,0 +1,32 @@
+#![no_main]
+
+use std::sync::{Arc, RwLock};
+use aleph_alpha_tokenizer::AlephAlphaTokenizer;
+use libfuzzer_sys::fuzz_target;
+use once_cell::sync::Lazy;
+use tokenizers::{
+    tokenizer::{EncodeInput, Tokenizer},
+    models::wordpiece::WordPiece,
+};
+
+static ALEPH: Lazy<Arc<RwLock<Tokenizer>>> = Lazy::new(|| Arc::new(RwLock::new(Tokenizer::new(
+    Box::new(AlephAlphaTokenizer::from_vocab("vocab.txt").unwrap())))));
+        
+static WORDPIECE: Lazy<Arc<RwLock<Tokenizer>>> = Lazy::new(|| Arc::new(RwLock::new(Tokenizer::new(
+        Box::new(WordPiece::from_files("vocab.txt").build().unwrap())))));
+
+// check if the string contains words larger than the character limit
+fn too_long_word(s: &str) -> bool {
+    s.split(char::is_whitespace).any(|w| w.chars().count() >= 100)
+}
+
+fuzz_target!(|s: String| {
+    // wordpiece starts with a follower token if a word starts with '##'.
+    // Also we don't store `[unusedX]` tokens, so those don't get matched.
+    // Finally we don't share wordpiece's character limit
+    if s.contains("##") || s.contains("[unused") || too_long_word(&s) { return; }
+    let input = EncodeInput::Single(s);
+    let aleph = ALEPH.read().unwrap().encode(input.clone(), true).ok();
+    let wordpiece = WORDPIECE.read().unwrap().encode(input, true).ok();
+    assert_eq!(aleph, wordpiece);
+});


### PR DESCRIPTION
* fix a typo in the unknown token string representation
* offsets returned from the `Model` are now character-, not byte-based
* add a fuzz test
* fix benchmark run without `huggingface` feature
* updated benchmark numbers
* update the optional `tokenizers` dependency to 0.10.1
* added CHANGELOG.md